### PR TITLE
package.json: use https:// instead of git:// for onvif.git

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version"      : "0.0.1-beta.9",
     "description"  : "Node Red nodes for communicating with OnVif compliant IP devices",
     "dependencies": {
-       "onvif": "git://github.com/agsh/onvif.git",
+       "onvif": "https://github.com/agsh/onvif.git",
        "request": ">= 2.88.2"
     },
     "author": {


### PR DESCRIPTION
On systems running behind proxies and/or firewalls, using HTTPS does often work well everywhere while git:// is not as ubiquitously successful.
